### PR TITLE
Use Bun native uuid function instead nodes uuid function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomUUIDv7 } from "bun";
 import { JSONRPCMessageSchema } from "@modelcontextprotocol/sdk/types.js";
 
 /**
@@ -19,7 +19,7 @@ export class BunSSEServerTransport {
    * @param _endpoint The endpoint where clients should POST messages
    */
   constructor(private _endpoint: string) {
-    this._sessionId = randomUUID();
+    this._sessionId = randomUUIDv7();
   }
 
   /**


### PR DESCRIPTION
I replaced the original UUID generation function used in Node.js with Bun’s native UUID function. This change is intended to enable a more purely Bun-based implementation of the project.